### PR TITLE
added and updated sponsor links 

### DIFF
--- a/src/components/Sponsors.tsx
+++ b/src/components/Sponsors.tsx
@@ -141,7 +141,7 @@ export const Sponsors = () => {
               />
             </a>
             <a
-              href="https://www.frost.com"
+              href="https://frost.com"
               target="_blank"
               rel="noopener noreferrer"
               className="transition-transform duration-300 hover:scale-105"
@@ -245,6 +245,7 @@ export const Sponsors = () => {
               />
             </a>
             <a
+              href="https://community.ucla.edu/studentorg/6365"
               target="_blank"
               rel="noopener noreferrer"
               className="transition-transform duration-300 hover:scale-105"
@@ -320,7 +321,7 @@ export const Sponsors = () => {
               />
             </a>
             <a
-              href="https://www.ivistechnologies.com"
+              href="https://ivis.com"
               target="_blank"
               rel="noopener noreferrer"
               className="transition-transform duration-300 hover:scale-105"


### PR DESCRIPTION
Updated sponsor links: Removed www from Frost & Sullivan URL, changed Ivis Technologies link to https://ivis.com, and added a link to the Innomed logo pointing to the UCLA student organization page.